### PR TITLE
fix bug where 0 truncated bytes weren't being re-inserted correctly

### DIFF
--- a/tool/generate.dart
+++ b/tool/generate.dart
@@ -690,7 +690,7 @@ Future<bool> generateCode(String dstPath, String srcDialectPath) async {
     content += '''factory ${msg.nameForDart}.parse(ByteData data_) {
     if (data_.lengthInBytes < ${msg.nameForDart}.mavlinkEncodedLength) {
       var len = ${msg.nameForDart}.mavlinkEncodedLength - data_.lengthInBytes;
-      var d = data_.buffer.asUint8List() + List<int>.filled(len, 0);
+      var d = data_.buffer.asUint8List().sublist(0, data_.lengthInBytes) + List<int>.filled(len, 0);
       data_ = Uint8List.fromList(d).buffer.asByteData();
     }
     ''';


### PR DESCRIPTION
Hello!

I found an issue regarding the re-insertion of truncated bytes that Mavlink 2.

I believe this is the same issue found by sagimann in #16.

When the mavlink message is encoded by the sender, it will truncate any 0's off the end of the message and send the shortened message to save over-the-wire space. The message length is already encoded in the message, so the receiver (us) can use this to re-insert any 0's to create a valid frame. 

Since the .buffer.asUint8List is a view of the bytebuffer on the transport (UDP in my case) it's seeing the raw, truncated bytes and assigning them to the new frame. This is why sagimann was seeing garbage data in his issue; the last two 0's in the expected frame were truncated, and the generator used the bytebuffer view to put the raw bytes in when it should have padded with 0's.

It looks like you knew all this already and have a handler for it, but the ``` + List<int>.filled(len, 0)``` doesn't appear to be working as described; doing that addition on the bytebuffer view doesn't seem to do anything (?) so instead I create a sublist from the bytebuffer and then do the addition of the filled 0's. This seems to work as expected. Idk if there's a performance hit from creating a sublist instead of referencing the bytebuffer directly. If so, we could test if the frame needs to be filled, and only then create the sublist? I haven't done any profiling but it seems to work ok for my purposes.

Anyways, this PR fixes it for my purposes; sagimann suggests what appears to me to be an identical solution but I'm new to dart so that might be incorrect.

Feedback appreciated! Love the library, thanks for writing it :)

Fixes #16 