### PR TITLE
Add handling for int/uint64 list fields

### DIFF
--- a/lib/mavlink_message.dart
+++ b/lib/mavlink_message.dart
@@ -66,6 +66,24 @@ abstract class MavlinkMessage {
     return ret;
   }
 
+  static Int64List asInt64List(ByteData data, int offsetInBytes, int length, [Endian endian=Endian.little]) {
+    Int64List ret = Int64List(length);
+    for (var i = 0; i < length; i++) {
+      ret[i] = data.getInt64(offsetInBytes + (i * 8), endian);
+    }
+
+    return ret;
+  }
+  
+  static Uint64List asUint64List(ByteData data, int offsetInBytes, int length, [Endian endian=Endian.little]) {
+    Uint64List ret = Uint64List(length);
+    for (var i = 0; i < length; i++) {
+      ret[i] = data.getUint64(offsetInBytes + (i * 8), endian);
+    }
+
+    return ret;
+  }
+
   static Float32List asFloat32List(ByteData data, int offsetInBytes, int length, [Endian endian=Endian.little]) {
     Float32List ret = Float32List(length);
     for (var i = 0; i < length; i++) {


### PR DESCRIPTION
One of my dialect messages uses a uint64_t list as one of it's fields, so I added a handler for int/uint64_t lists. You had done all the hard work already i just copy/pasted in the datatypes you already created

side note: i was surprised that no messages in common use int/uint64_t arrays! Makes sense why it didn't come up until now...