### PR TITLE
Allow Generate.dart to Merge Enums

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: MAVLink library for Dart.
 version: 0.1.0
 repository: https://github.com/nus/dart_mavlink
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=3.0.0'
 dev_dependencies:
   lints: ^1.0.0
   path: ^1.8.0


### PR DESCRIPTION
Hello! Hope it's OK I'm opening more PRs; I've been using your library a lot lately and I love it. Ran into a few issues that I've resolved and hoped it be OK if I shared!

I have a custom dialect that adds custom MAV_CMD's and so I needed the generator to be able to merge enums from multiple dialects so that I didn't have to modify common.xml directly.

So my dialect.xml has, for example

```(xml)
    <include>common.xml</include>
    <version>1</version>
    <dialect>8</dialect>
        <enum name="MAV_CMD">
            <entry value="" name="MAV_CMD_START_EOS_SCAN">
                <description>Starts a scan on the targeted scanner. Takes no arguments</description>
            </entry>
        </enum>
```

Before, the generator would add all the enums from common.xml, then when it hit my extension, it would say "hey this enum already exists, continue" and it wouldn't be added.

I extended your ```_hasName``` function to return a record with ```(bool, DialectEnum)```, rather than writing a new ```DialectEnum _getEnumFromName(String name)``` although there really wouldnt' be anything wrong with that if you wanted to keep the _hasName the same.

Additionally, to use the records feature I had to bump the SDK up to >3.0. If we wanted to keep the sdk requirements at 2.x then we could definitely do that and refactor to not use records. I'm new to Dart, so the records feel like tuples to my Python brain hah

I have a few gross ```!``` null checks in there because it was quick to prototype and since this is a script I know that nothing will modify the object since it all runs sequentially, but the dart static checker didn't accept me field-promoting a non-private variable in DialectEntry, and changing it to private made a lot more red squigglies in the code. If you think this feature is worth adding to the library, I may refactor that to make it cleaner.

Please take this as a draft! I don't want to step on your code, but did want to offer what I found useful in my use-case.

Thanks!