### PR TITLE
Allow Exponentiation Operator in Xml

### DIFF
--- a/test/generate_test.dart
+++ b/test/generate_test.dart
@@ -29,7 +29,7 @@ void main() {
     expect(dialectDoc.version, 3);
     expect(dialectDoc.dialect, 3);
 
-    expect(dialectDoc.enums.length, 3);
+    expect(dialectDoc.enums.length, 4);
 
     var e = dialectDoc.enums.elementAt(0);
     expect(e.name, "ENUM_00");
@@ -57,6 +57,21 @@ void main() {
     expect(e.name, "ENUM_02");
     expect(e.description, "Description of ENUM_02");
     expect(e.entries, isNotNull);
+
+    e = dialectDoc.enums.elementAt(3);
+    expect(e.name, "ENUM_03");
+    entries = e.entries;
+    expect(entries?.elementAt(0).value, 1);
+    expect(entries?.elementAt(1).value, 2);
+    expect(entries?.elementAt(2).value, 4);
+    expect(entries?.elementAt(3).value, 8);
+    expect(entries?.elementAt(4).value, 16);
+    expect(entries?.elementAt(5).value, 32);
+    expect(entries?.elementAt(6).value, 64);
+    expect(entries?.elementAt(7).value, 128);
+    expect(entries?.elementAt(8).value, 1152921504606846976);
+    expect(entries?.elementAt(9).value, 2305843009213693952);
+    expect(entries?.elementAt(10).value, 4611686018427387904);
   });
 
   test('Parse t04, name of enums is empty', () async {

--- a/test/mavlink_dialect/t03.xml
+++ b/test/mavlink_dialect/t03.xml
@@ -25,6 +25,20 @@
         <description>Description of ENUM_02_ENTRY_01</description>
       </entry>
     </enum>
+    <enum name="ENUM_03">
+      <description>Description of ENUM_03. Contains different representations of integer values</description>
+      <entry value="1" name="BIT0"/>
+      <entry value="2" name="BIT1"/>
+      <entry value="2**2" name="BIT2"/>
+      <entry value="2**3" name="BIT3"/>
+      <entry value="0b00010000" name="BIT4"/>
+      <entry value="0b00100000" name="BIT5"/>
+      <entry value="0x40" name="BIT6"/>
+      <entry value="0x80" name="BIT7"/>
+      <entry value="0b1000000000000000000000000000000000000000000000000000000000000" name="BIT60" />
+      <entry value="2305843009213693952" name="BIT61" />
+      <entry value="2**62" name="BIT62" />
+    </enum>
   </enums>
 
   <messages>

--- a/tool/generate.dart
+++ b/tool/generate.dart
@@ -124,7 +124,8 @@ class DialectEntry {
       throw FormatException('The name of deprecated element should not be empty.');
     }
 
-    int value = int.parse(elmEntry.getAttribute('value') ?? '');
+    var valueStr = (elmEntry.getAttribute('value') ?? '');
+    int value = int.parse(valueStr);
     String? description = elmEntry.getElement('description')?.text;
 
     var deprecated = DialectDeprecated.parseElement(elmEntry.getElement('deprecated'));


### PR DESCRIPTION
I saw issue #11 open a thought I'd take a crack at it!

Dart already handled the hex (eg: 0x20) natively in the ```int.parse```. It also handled the binary natively if you strip out the "0b" starter so that was pretty easy. Otherwise just added a test of "starts with 2**" and split the string on that, then used ```math.pow``` to make the value.

I added test cases for each of these as well.

fixes #11 