### PR TITLE
Fix truncating 0s when encoding frame

### DIFF
--- a/test/mavlink_frame_serialize_test.dart
+++ b/test/mavlink_frame_serialize_test.dart
@@ -1,0 +1,43 @@
+import 'package:dart_mavlink/dialects/common.dart';
+import 'package:dart_mavlink/mavlink_frame.dart';
+import 'package:dart_mavlink/mavlink_version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {});
+
+  test('Serialize full v2 frame with extension fields', () async {
+    // In this message mission type is an extension field
+    var msg = MissionRequestList(targetSystem: 1, targetComponent: 2, missionType: 3);
+    var frame = MavlinkFrame(MavlinkVersion.v2, 0, 255, 190, msg);
+    var frameSerialized = frame.serialize();
+    var expectedBytes = [253, 3, 0, 0, 0, 255, 190, 43, 0, 0, 1, 2, 3, 243, 192];
+    expect(expectedBytes, frameSerialized.buffer.asUint8List());
+  });
+
+  test('Serialize full v2 frame with extension fields, last value set to 0 to test truncation', () async {
+    // In this message mission type is an extension field, set to 0 to test truncation
+    var msg = MissionRequestList(targetSystem: 1, targetComponent: 2, missionType: 0);
+    var frame = MavlinkFrame(MavlinkVersion.v2, 0, 255, 190, msg);
+    var frameSerialized = frame.serialize();
+    var expectedBytes = [253, 2, 0, 0, 0, 255, 190, 43, 0, 0, 1, 2, 192, 186];
+    expect(expectedBytes, frameSerialized.buffer.asUint8List());
+  });
+
+  test('Serialize full v2 frame with extension fields, all values set to 0 to test over-truncation', () async {
+    // all values set to zero in message body, the first 0 byte should be retained
+    var msg = MissionRequestList(targetSystem: 0, targetComponent: 0, missionType: 0);
+    var frame = MavlinkFrame(MavlinkVersion.v2, 0, 255, 190, msg);
+    var frameSerialized = frame.serialize();
+    var expectedBytes = [253, 1, 0, 0, 0, 255, 190, 43, 0, 0, 0, 158, 53];
+    expect(expectedBytes, frameSerialized.buffer.asUint8List());
+  });
+
+  test("Serialize large message with lots of 0 truncated bytes", () async {
+    var msg = FileTransferProtocol(targetNetwork: 1, targetSystem: 2, targetComponent: 3, payload: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30]);
+    var frame = MavlinkFrame(MavlinkVersion.v2, 0, 255, 190, msg);
+    var frameSerialized = frame.serialize();
+    var expectedBytes = [253, 13, 0, 0, 0, 255, 190, 110, 0, 0, 1, 2, 3, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 141, 124];
+    expect(expectedBytes, frameSerialized);
+  });
+}

--- a/test/mavlink_parser_v2_test.dart
+++ b/test/mavlink_parser_v2_test.dart
@@ -1,12 +1,10 @@
 import 'package:dart_mavlink/dialects/common.dart';
-import 'package:dart_mavlink/mavlink.dart';
 import 'package:dart_mavlink/mavlink_parser.dart';
 import 'package:dart_mavlink/mavlink_version.dart';
+import 'package:dart_mavlink/mavlink_frame.dart';
 import 'package:test/test.dart';
 import 'dart:typed_data';
 import 'dart:convert';
-
-import 'package:xml/xml.dart';
 
 void main() {
   MavlinkParser? parser;

--- a/test/mavlink_parser_v2_test.dart
+++ b/test/mavlink_parser_v2_test.dart
@@ -105,17 +105,19 @@ test("Testing multiple statustext messages back to back. Testing truncated zeros
 
   var parser = MavlinkParser(MavlinkDialectCommon());
   String str = "";
+  var numParsed = 0;
   parser.stream.listen((MavlinkFrame frame){
     if (frame.message is Statustext){
       var msg = frame.message as Statustext;
       List<int> trimmed = List.from(msg.text);
       trimmed.removeWhere((item) => item == 0x00);
       str += utf8.decode(trimmed);
+      numParsed += 1;
     }
   });
 
   parser.parse(d);
-  await Future.delayed(Duration(milliseconds: 500));
+  await Future.doWhile(() => Future(() async {return numParsed <5;}));
   expect(str, "loremipsumdolorsitamet");
 });
 }


### PR DESCRIPTION
I noticed that when serializing frames, trailing 0's weren't being truncated. I added some tests to verify this behavior. 

I used pymavlink to generate some reference serialized bytes and used them as the expected value in the tests. I can include the python file I used to generate the serialized frames if that's helpful. Currently leaving it off to keep the repo tidy.

I chose to do the truncation at the ```frame.serialize()``` level, although it could also be done at the ```message.serialize()``` level. I feel like it made more sense at the frame level since that keeps all the CRC stuff in the same location. 