### PR TITLE
Add toJson, Expose msgId, Specify dialect.xml on generate.dart

### DIFF
--- a/lib/mavlink_frame.dart
+++ b/lib/mavlink_frame.dart
@@ -27,6 +27,16 @@ class MavlinkFrame {
     return MavlinkFrame(MavlinkVersion.v2, sequence, systemId, componentId, message);
   }
 
+  Map<String, dynamic> toJson() {
+    return {
+      'version': version,
+      'sequence': sequence,
+      'systemId': systemId,
+      'componentId': componentId,
+      'message': message.toJson(),
+    };
+  }
+
   Uint8List serialize() {
     if (version == MavlinkVersion.v1) {
       return _serializeV1();

--- a/lib/mavlink_frame.dart
+++ b/lib/mavlink_frame.dart
@@ -29,7 +29,7 @@ class MavlinkFrame {
 
   Map<String, dynamic> toJson() {
     return {
-      'version': version,
+      'version': version.name,
       'sequence': sequence,
       'systemId': systemId,
       'componentId': componentId,

--- a/lib/mavlink_message.dart
+++ b/lib/mavlink_message.dart
@@ -9,7 +9,7 @@ abstract class MavlinkMessage {
 
   int get mavlinkMessageId;
   int get mavlinkCrcExtra;
-
+  Map <String, dynamic> toJson();
   ByteData serialize();
 
   static Int8List asInt8List(ByteData data, int offsetInBytes, int length) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: MAVLink library for Dart.
 version: 0.1.0
 repository: https://github.com/nus/dart_mavlink
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 dev_dependencies:
   lints: ^1.0.0
   path: ^1.8.0

--- a/tool/generate.dart
+++ b/tool/generate.dart
@@ -653,16 +653,16 @@ Future<bool> generateCode(String dstPath, String srcDialectPath) async {
     content += '/// ${msg.name}\n';
     content += 'class ${msg.nameForDart} implements MavlinkMessage {\n';
     content += '\n';
-    content += 'static const int _mavlinkMessageId = ${msg.id};\n';
+    content += 'static const int msgId = ${msg.id};\n';
     content += '\n';
-    content += 'static const int _mavlinkCrcExtra = ${msg.calculateCrcExtra()};\n';
+    content += 'static const int crcExtra = ${msg.calculateCrcExtra()};\n';
     content += '\n';
     content += 'static const int mavlinkEncodedLength = ${msg.calculateEncodedLength()};\n';
 
     content +='\n';
-    content +='@override int get mavlinkMessageId => _mavlinkMessageId;\n';
+    content +='@override int get mavlinkMessageId => msgId;\n';
     content +='\n';
-    content +='@override int get mavlinkCrcExtra => _mavlinkCrcExtra;\n';
+    content +='@override int get mavlinkCrcExtra => crcExtra;\n';
 
     for (var field in msg.orderedFields) {
       content += generateAsDartDocumentation(field.description);
@@ -713,6 +713,16 @@ Future<bool> generateCode(String dstPath, String srcDialectPath) async {
     }
     content += ');';
     content += '}';
+
+    // toJson builder
+    content += '@override Map<String, dynamic> toJson() => {\n';
+    content += '\'msgId\': msgId, \n';
+     for (var f in msg.orderedFields) {
+      content +=
+          '\'${f.nameForDart}\': ${f.nameForDart},\n';
+    }
+    content += '};\n';
+    content += '\n';
 
     // parse constructor.
     content += '''factory ${msg.nameForDart}.parse(ByteData data_) {
@@ -843,7 +853,7 @@ switch (messageID) {
   ''';
   for (var msg in doc.messages) {
     content += '''case ${msg.id}:
-return ${msg.nameForDart}._mavlinkCrcExtra;
+return ${msg.nameForDart}.crcExtra;
 ''';
   }
 

--- a/tool/generate.dart
+++ b/tool/generate.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:collection';
 import 'dart:math';
 import 'package:xml/xml.dart';
+import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import 'package:dart_mavlink/crc.dart';
 
@@ -908,13 +909,34 @@ Future<void> runFormatter(String path) async {
   await Process.run('dart', ['format', path]);
 }
 
-void main() async {
-  final dir = await Directory('mavlink/message_definitions/v1.0/').list()
-    .map((f) => f.path.toString())
-    .where((f) =>
-      (!f.endsWith('all.xml')) && (!f.contains('test'))
-    )
-    .toList();
+void main(List<String> arguments) async {
+  ArgParser parser = ArgParser();
+  parser.addOption("dialect",
+      help:
+          "Path to the dialect.xml file to generate dart files from. Leave emtpy to parse all dialect files in the default location.",
+      abbr: "d");
+  parser.addFlag("help",
+      abbr: "h", negatable: false, help: "display usage help", callback: (display) {
+    if(!display) return;
+    print(parser.usage);
+    exit(0);
+  });
+
+  ArgResults argResults = parser.parse(arguments);
+  final String? dialect = argResults["dialect"];
+
+  List dir;
+  if (dialect == null) {
+    dir = await Directory('mavlink/message_definitions/v1.0/')
+        .list()
+        .map((f) => f.path.toString())
+        .where((f) => (!f.endsWith('all.xml')) && (!f.contains('test')))
+        .toList();
+  }
+  else
+  {
+    dir = [dialect];
+  }
 
   var dstDir = 'lib/dialects';
   await Directory(dstDir).create(recursive: true);


### PR DESCRIPTION
As requested in #23 I added a toJson method for both the messages and the frames. I followed the example in the Flutter docs. https://docs.flutter.dev/data-and-backend/serialization/json#serializing-json-inside-model-classes

Here's an example of creating a frame and printing it toJson. The message also has a toJson() which is just recursively called when the frame toJson() is called

```dart
var status = Statustext(chunkSeq: 1, id: 30, severity: 3, text: [0,1,2,4,6]);
var frame = MavlinkFrame(MavlinkVersion.v2, 2, 4, 5, status);
var json = jsonEncode(frame.toJson());
print(json);
```

and outputs: 
```{"version":"v2","sequence":2,"systemId":4,"componentId":5,"message":{"msgId":253,"severity":3,"text":[0,1,2,4,6],"id":30,"chunkSeq":1}}```

There are a lot of ways that the toJson could be used, so I kinda took the path of least resistance. I'm assuming that the primary use (at least this is how I intend to use it!) is a handy way to print stuff to terminal for debugging or logging, and it doesn't need to be a "full" implementation i.e., I don't need convert "v2" to the magic 0xFE or whatever actually happens in the packet serialization. 

Also as requested I added a public way to access the static attribute of the message classes MavlinkMessageId. This is really useful for sending mavcommands and other commands/messages that use a messageID as a parameter.

There's still the existing instance getter, but now you don't need to instantiate the class to access it's ID. I kind of considered making an empty constructor for the messages so you could do ```Heartbeat().mavlinkMessageId``` but idk it felt like the least good solution.

 Its a bit odd since theres now a static attribute ```Heartbeat.msgId``` and an instance getter that fetch the same value with different names, but I've seen this in other places too, and it doesn't seem to so bad.

Getting via instance (existing implementation):
```dart
  var heartbeat = Heartbeat(autopilot: 1, customMode: 1, type: 1, baseMode: 1, systemStatus: 1, mavlinkVersion: 1);
  var id = heartbeat.mavlinkMessageId;
```

Getting via static attribute (new way)
```dart
  var id = Heartbeat.msgId;
```

Finally, I added a simple argparser to the generate.dart so you can specify which file is generated. I've used this in dev a lot for my dialect.

```dart .\tool\generate.dart -d .\mavlink\message_definitions\v1.0\altamus.xml```

as done in the past, I'm just including the changes without the dialect changes so the test will fail, but this keeps the diff clean.

Feedback appreciated :)